### PR TITLE
Support preserving insert mode

### DIFF
--- a/lua/nerdy/init.lua
+++ b/lua/nerdy/init.lua
@@ -2,6 +2,7 @@ local nerdy = {}
 
 nerdy.list = function()
     local icon_list = require('nerdy.icons')
+    local initial_mode = vim.api.nvim_get_mode().mode
 
     vim.ui.select(icon_list, {
         prompt = 'Nerdy Icons',
@@ -11,7 +12,13 @@ nerdy.list = function()
         end,
     }, function(item, _)
         if item ~= nil then
-            vim.api.nvim_put({ item.char }, 'c', true, true)
+            local is_insert_mode = (initial_mode == 'i')
+
+            vim.api.nvim_put({ item.char }, 'c', not is_insert_mode, true)
+
+            if is_insert_mode then
+              vim.cmd('startinsert')
+            end
         end
     end)
 end

--- a/lua/nerdy/init.lua
+++ b/lua/nerdy/init.lua
@@ -17,7 +17,7 @@ nerdy.list = function()
             vim.api.nvim_put({ item.char }, 'c', not is_insert_mode, true)
 
             if is_insert_mode then
-              vim.cmd('startinsert')
+                vim.cmd('startinsert')
             end
         end
     end)


### PR DESCRIPTION
Creating a keybind for insert mode results in unintuitive behavior:
  Icon is inserted after the the current cursor instead of at/before
  Vim reverts to normal mode after insertion is completed

These changes correct the above behaviors.

## What does the PR do? (Required)

- [x] Preserves insert mode after insertion, if insert mode was used to run nerdy()
- [x] Ensures icon is inserted at the cursor instead of after, if insert mode was used to run nerdy()
- [x] Takes no effect on calls run in normal mode

Include information that will reviewers understand the changes better, now or in future.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [ ] I have added relevant documentation and tests for the changes
- - Note: No relevant documentation to add that I can think of
- - No tests added - no familiarity with running them. If you have recommendations on this, please let me know.
- [x] I have followed the style guidelines of this project

## Evidence (Required)

Configuration:
![image](https://github.com/user-attachments/assets/125671d9-97cd-45af-ba3b-bd63c3d9a92f)

Manual test execution:
![image](https://github.com/user-attachments/assets/268254e8-51a5-4b37-8ad1-d4d0deceb828)

Note that images are for demonstrative purposes only, and have been cobbled together in image editor.
