### PR TITLE
fix: preserve cursor position

### DIFF
--- a/lua/nerdy/init.lua
+++ b/lua/nerdy/init.lua
@@ -3,6 +3,7 @@ local nerdy = {}
 nerdy.list = function()
     local icon_list = require('nerdy.icons')
     local initial_mode = vim.api.nvim_get_mode().mode
+    local cursor_position = vim.api.nvim_win_get_cursor(0)
 
     vim.ui.select(icon_list, {
         prompt = 'Nerdy Icons',
@@ -14,11 +15,12 @@ nerdy.list = function()
         if item ~= nil then
             local is_insert_mode = (initial_mode == 'i')
 
-            vim.api.nvim_put({ item.char }, 'c', not is_insert_mode, true)
-
             if is_insert_mode then
                 vim.cmd('startinsert')
             end
+            vim.api.nvim_win_set_cursor(0, cursor_position)
+
+            vim.api.nvim_put({ item.char }, 'c', not is_insert_mode, true)
         end
     end)
 end


### PR DESCRIPTION
Cursor position in insert mode, when at the end of a line, was not being preserved

## What does the PR do? (Required)

- [x] Fixed issue #10

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
    - Tests considered, but either:
    - A: Not sure how to write a test that uses an actual buffer to test for actual cursor location changes
    - B: Mocking to detect nvim_win_set_cursor seems worthless, as the function being called doesn't guarantee the desired outcome from the overall process.
- [x] I have followed the style guidelines of this project
