### PR TITLE
fix: recommended setup's lazy-loading breaks default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ Introducing nerdy.nvim, a super handy plugin that lets you search, preview and i
     cmd = 'Nerdy',
     opts = {
         max_recents = 30, -- Configure recent icons limit
-        add_default_keybindings = true, -- Add default keybindings
         copy_to_clipboard = false, -- Copy glyph to clipboard instead of inserting
         copy_register = '+', -- Register to use for copying (if `copy_to_clipboard` is true)
-    }
+    },
+    keys = {
+        { '<leader>in', ':Nerdy list<CR>',    desc = "Browse nerd icons", noremap = true, silent = true },
+        { '<leader>iN', ':Nerdy recents<CR>', desc = "Browse recent nerd icons", noremap = true, silent = true },
+    },
 },
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,6 @@ Introducing nerdy.nvim, a super handy plugin that lets you search, preview and i
 - Use `<Ctrl-a>` to select all glyphs on a filtered list
 - Use `<Enter>` to confirm your selection
 
-#### ⌨️ Keybindings
-
-By default, these are the configured keybindings.
-
-| Keybinding   | Command                           | Description               |
-| ------------ | --------------------------------- | ------------------------- |
-| `<leader>in` | `:Nerdy list<CR>` or `:Nerdy<CR>` | Browser nerd icons        |
-| `<leader>iN` | `:Nerdy recents<CR>`              | Browser recent nerd icons |
-
-I recommend customizing these keybindings based on your preferences.
-
-Use `:help nerdy` for more details.
-
 #### 🔭 Telescope Extension
 
 Nerdy also comes with a Telescope extension, to use it add the following to your telescope configs.

--- a/doc/nerdy.txt
+++ b/doc/nerdy.txt
@@ -44,10 +44,13 @@ INSTALLATION ~
         cmd = 'Nerdy',
         opts = {
             max_recents = 30, -- Configure recent icons limit
-            add_default_keybindings = true, -- Add default keybindings
             copy_to_clipboard = false, -- Copy glyph to clipboard instead of inserting
             copy_register = '+', -- Register to use for copying (if `copy_to_clipboard` is true)
-        }
+        },
+        keys = {
+            { '<leader>in', ':Nerdy list<CR>', desc = "Browse nerd icons", noremap = true, silent = true },
+            { '<leader>iN', ':Nerdy recents<CR>', desc = "Browse recent nerd icons", noremap = true, silent = true },
+        },
     },
 <
 

--- a/lua/nerdy/commands.lua
+++ b/lua/nerdy/commands.lua
@@ -77,10 +77,6 @@ end
 ---Setup Nerdy commands
 function M.setup()
     add_nerdy_command()
-    if config.add_default_keybindings then
-        vim.api.nvim_set_keymap('n', '<leader>in', ':Nerdy list<CR>', { noremap = true, silent = true })
-        vim.api.nvim_set_keymap('n', '<leader>iN', ':Nerdy recents<CR>', { noremap = true, silent = true })
-    end
 end
 
 return M

--- a/lua/nerdy/config.lua
+++ b/lua/nerdy/config.lua
@@ -2,11 +2,9 @@ local M = {}
 
 ---@class nerdy.config
 ---@field max_recents integer : Max number of recent icons to keep
----@field add_default_keybindings boolean : Whether to add default keybindings
 ---@field copy_to_clipboard boolean : -- Copy glyph to clipboard instead of inserting
 M.config = {
     max_recents = 30,
-    add_default_keybindings = true,
     copy_to_clipboard = false,
     copy_register = '+',
 }


### PR DESCRIPTION
Thanks for this plugin, it has saved me many a trip to the nerdy font website!

## What does the PR do? (Required)

`cmd = 'Nerdy'` in the recommended lazy.nvim setup means the plugin is not loaded _until_ that command. Thus the internal default keymaps are not created and the user must manually run `:Nerdy` to load and use the plugin.

I chose to solve this by moving the internal keymaps to lazy.nvim's `keys` array, so the plugin loads on these keymaps. This fixes the lazy-loading issue and adheres to [best practices](https://github.com/lumen-oss/nvim-best-practices#keyboard-keymaps) 🙂 

But you could also just remove the `cmd` key from the recommended lazy.nvim config.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

Without this PR: Enters insert mode because the keys aren't mapped.

https://github.com/user-attachments/assets/f9e78945-deab-4512-8252-bb8c328763be

With this PR: Opens select as expected.

https://github.com/user-attachments/assets/abd28677-65d4-4996-9240-e2b57e91f307

