### PR TITLE
fix(telescope): respect copy_to_clipboard in extensions

### DIFF
--- a/lua/telescope/_extensions/nerdy_icons.lua
+++ b/lua/telescope/_extensions/nerdy_icons.lua
@@ -6,6 +6,7 @@ local action_state = require('telescope.actions.state')
 local icon_list = require('nerdy.icons')
 
 local recent_utils = require('nerdy.recents')
+local config_module = require('nerdy.config')
 
 return function(opts)
     opts = opts or require('telescope.themes').get_dropdown({})
@@ -29,7 +30,11 @@ return function(opts)
                     local icon = selected_entry.char
                     recent_utils.add_to_recent(selected_entry)
                     actions.close(prompt_bufnr)
-                    vim.api.nvim_put({ icon }, 'c', true, true)
+                    if config_module.config.copy_to_clipboard then
+                        vim.fn.setreg(config_module.config.copy_register or '+', icon)
+                    else
+                        vim.api.nvim_put({ icon }, 'c', true, true)
+                    end
                 end)
                 return true
             end,

--- a/lua/telescope/_extensions/nerdy_recents.lua
+++ b/lua/telescope/_extensions/nerdy_recents.lua
@@ -5,6 +5,7 @@ local actions = require('telescope.actions')
 local action_state = require('telescope.actions.state')
 
 local recent_utils = require('nerdy.recents')
+local config_module = require('nerdy.config')
 
 return function(opts)
     local recent_icons = recent_utils.load_recent_icons()
@@ -35,7 +36,11 @@ return function(opts)
                     local icon = selected_entry.char
                     recent_utils.add_to_recent(selected_entry)
                     actions.close(prompt_bufnr)
-                    vim.api.nvim_put({ icon }, 'c', true, true)
+                    if config_module.config.copy_to_clipboard then
+                        vim.fn.setreg(config_module.config.copy_register or '+', icon)
+                    else
+                        vim.api.nvim_put({ icon }, 'c', true, true)
+                    end
                 end)
                 return true
             end,


### PR DESCRIPTION
Closes #25.

The Telescope `nerdy` and `nerdy_recents` extensions always called `vim.api.nvim_put` on selection, ignoring the `copy_to_clipboard` config. Mirrors the existing behavior in `fetcher.lua` `single_select`/`multi_select` so both pickers honor `copy_to_clipboard` and `copy_register`.